### PR TITLE
Implement and use WebAuthenticationHelper and tests. Closes #2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
         <javax.inject.version>1</javax.inject.version>
         <jsr311.version>1.1.1</jsr311.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
+        <junit.version>4.12</junit.version>
+        <mockito.version>1.8.5</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -128,15 +130,36 @@
 
         <!--test dependencies-->
         <dependency>
+            <groupId>com.atlassian.bitbucket.server</groupId>
+            <artifactId>bitbucket-test-util</artifactId>
+            <version>${bitbucket.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.plugins</groupId>
+            <artifactId>atlassian-plugins-osgi-testrunner</artifactId>
+            <version>${plugin.testrunner.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.8.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/de/aservo/atlassian/bitbucket/confapi/helper/WebAuthenticationHelper.java
+++ b/src/main/java/de/aservo/atlassian/bitbucket/confapi/helper/WebAuthenticationHelper.java
@@ -1,0 +1,52 @@
+package de.aservo.atlassian.bitbucket.confapi.helper;
+
+import com.atlassian.bitbucket.auth.AuthenticationContext;
+import com.atlassian.bitbucket.permission.Permission;
+import com.atlassian.bitbucket.permission.PermissionService;
+import com.atlassian.bitbucket.user.ApplicationUser;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+@Named
+public class WebAuthenticationHelper {
+
+    @ComponentImport
+    private final AuthenticationContext authenticationContext;
+
+    @ComponentImport
+    private final PermissionService permissionService;
+
+    @Inject
+    public WebAuthenticationHelper(
+            final AuthenticationContext authenticationContext,
+            final PermissionService permissionService) {
+
+        this.authenticationContext = authenticationContext;
+        this.permissionService = permissionService;
+    }
+
+    public ApplicationUser getAuthenticatedUser() {
+        return authenticationContext.getCurrentUser();
+    }
+
+    public void mustBeSysAdmin() {
+        final ApplicationUser user = getAuthenticatedUser();
+
+        if (user == null) {
+            // NOSONAR: Ignore that WebApplicationException is a RuntimeException
+            throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+        }
+
+        final boolean isSysAdmin = permissionService.hasGlobalPermission(user, Permission.SYS_ADMIN);
+
+        if (!isSysAdmin) {
+            // NOSONAR: Ignore that WebApplicationException is a RuntimeException
+            throw new WebApplicationException(Response.Status.FORBIDDEN);
+        }
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/bitbucket/confapi/rest/SettingsResource.java
+++ b/src/main/java/de/aservo/atlassian/bitbucket/confapi/rest/SettingsResource.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.bitbucket.confapi.rest;
 
 import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import de.aservo.atlassian.bitbucket.confapi.helper.WebAuthenticationHelper;
 import de.aservo.atlassian.bitbucket.confapi.model.SettingsBean;
 
 import javax.inject.Inject;
@@ -14,30 +15,42 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("settings")
+@Path(SettingsResource.SETTINGS_PATH)
 @Produces({MediaType.APPLICATION_JSON})
 @Named
 public class SettingsResource {
 
+    public static final String SETTINGS_PATH = "settings";
+
     @ComponentImport
     private final ApplicationPropertiesService applicationPropertiesService;
 
+    private final WebAuthenticationHelper webAuthenticationHelper;
+
     @Inject
     public SettingsResource(
-            final ApplicationPropertiesService applicationPropertiesService) {
+            final ApplicationPropertiesService applicationPropertiesService,
+            final WebAuthenticationHelper webAuthenticationHelper) {
 
         this.applicationPropertiesService = applicationPropertiesService;
+        this.webAuthenticationHelper = webAuthenticationHelper;
     }
 
     @GET
     public Response getSettings() {
+        webAuthenticationHelper.mustBeSysAdmin();
+
         final SettingsBean settingsBean = SettingsBean.from(applicationPropertiesService);
         return Response.ok(settingsBean).build();
     }
 
     @PUT
     @Consumes({MediaType.APPLICATION_JSON})
-    public Response putSettings(SettingsBean settings) {
+    public Response putSettings(
+            final SettingsBean settings) {
+
+        webAuthenticationHelper.mustBeSysAdmin();
+
         if (settings.getBaseurl() != null) {
             applicationPropertiesService.setBaseURL(settings.getBaseurl());
         }
@@ -48,7 +61,8 @@ public class SettingsResource {
             applicationPropertiesService.setDisplayName(settings.getTitle());
         }
 
-        return getSettings();
+        final SettingsBean settingsBean = SettingsBean.from(applicationPropertiesService);
+        return Response.ok(settingsBean).build();
     }
 
 }

--- a/src/test/java/de/aservo/atlassian/bitbucket/confapi/helper/WebAuthenticationHelperTest.java
+++ b/src/test/java/de/aservo/atlassian/bitbucket/confapi/helper/WebAuthenticationHelperTest.java
@@ -1,0 +1,65 @@
+package de.aservo.atlassian.bitbucket.confapi.helper;
+
+import com.atlassian.bitbucket.auth.AuthenticationContext;
+import com.atlassian.bitbucket.permission.Permission;
+import com.atlassian.bitbucket.permission.PermissionService;
+import com.atlassian.bitbucket.user.ApplicationUser;
+import com.atlassian.bitbucket.user.TestApplicationUser;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.WebApplicationException;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebAuthenticationHelperTest {
+
+    private final ApplicationUser user = new TestApplicationUser("test");
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Mock
+    private AuthenticationContext authenticationContext;
+
+    @Mock
+    private PermissionService permissionService;
+
+    private WebAuthenticationHelper webAuthenticationHelper;
+
+    @Before
+    public void setup() {
+        webAuthenticationHelper = new WebAuthenticationHelper(
+                authenticationContext, permissionService);
+    }
+
+    @Test
+    public void testNotAuthenticated() {
+        when(webAuthenticationHelper.getAuthenticatedUser()).thenReturn(null);
+        exceptionRule.expect(WebApplicationException.class);
+        webAuthenticationHelper.mustBeSysAdmin();
+    }
+
+    @Test
+    public void testNotSysAdmin() {
+        when(webAuthenticationHelper.getAuthenticatedUser()).thenReturn(user);
+        when(permissionService.hasGlobalPermission(user, Permission.SYS_ADMIN)).thenReturn(false);
+        exceptionRule.expect(WebApplicationException.class);
+        webAuthenticationHelper.mustBeSysAdmin();
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // Ignore that no assertion is present
+    public void testIsSysAdmin() {
+        when(webAuthenticationHelper.getAuthenticatedUser()).thenReturn(user);
+        when(permissionService.hasGlobalPermission(user, Permission.SYS_ADMIN)).thenReturn(true);
+        webAuthenticationHelper.mustBeSysAdmin();
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/bitbucket/confapi/rest/SettingsResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/bitbucket/confapi/rest/SettingsResourceTest.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.bitbucket.confapi.rest;
 
 import com.atlassian.bitbucket.server.ApplicationMode;
 import com.atlassian.bitbucket.server.ApplicationPropertiesService;
+import de.aservo.atlassian.bitbucket.confapi.helper.WebAuthenticationHelper;
 import de.aservo.atlassian.bitbucket.confapi.model.SettingsBean;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +26,9 @@ public class SettingsResourceTest {
     @Mock
     private ApplicationPropertiesService applicationPropertiesService;
 
+    @Mock
+    private WebAuthenticationHelper webAuthenticationHelper;
+
     private SettingsResource settingsResource;
 
     @Before
@@ -33,13 +37,16 @@ public class SettingsResourceTest {
         when(applicationPropertiesService.getMode()).thenReturn(ApplicationMode.valueOf(MODE));
         when(applicationPropertiesService.getDisplayName()).thenReturn(TITLE);
 
-        settingsResource = new SettingsResource(applicationPropertiesService);
+        settingsResource = new SettingsResource(
+                applicationPropertiesService, webAuthenticationHelper);
     }
 
     @Test
     public void testGetSettings() {
         final Response response = settingsResource.getSettings();
         final SettingsBean bean = (SettingsBean) response.getEntity();
+
+        verify(webAuthenticationHelper).mustBeSysAdmin();
 
         assertEquals(applicationPropertiesService.getBaseUrl(), bean.getBaseurl());
         assertEquals(applicationPropertiesService.getMode(), bean.getMode());
@@ -50,6 +57,8 @@ public class SettingsResourceTest {
     public void testSetSettings() {
         final SettingsBean settingsBean = SettingsBean.from(applicationPropertiesService);
         final Response response = settingsResource.putSettings(settingsBean);
+
+        verify(webAuthenticationHelper).mustBeSysAdmin();
 
         assertNotNull(applicationPropertiesService.getBaseUrl());
         assertNotNull(applicationPropertiesService.getDisplayName());

--- a/src/test/java/it/de/aservo/atlassian/bitbucket/confapi/rest/ResourceAccessFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/bitbucket/confapi/rest/ResourceAccessFuncTest.java
@@ -1,0 +1,108 @@
+package it.de.aservo.atlassian.bitbucket.confapi.rest;
+
+import com.atlassian.bitbucket.permission.Permission;
+import com.atlassian.bitbucket.user.ApplicationUser;
+import com.atlassian.bitbucket.user.DetailedUser;
+import com.atlassian.bitbucket.user.SecurityService;
+import com.atlassian.bitbucket.user.UserAdminService;
+import com.atlassian.bitbucket.util.UncheckedOperation;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.atlassian.plugins.osgi.test.AtlassianPluginsTestRunner;
+import org.apache.wink.client.ClientConfig;
+import org.apache.wink.client.Resource;
+import org.apache.wink.client.RestClient;
+import org.apache.wink.client.handlers.BasicAuthSecurityHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response.Status;
+
+import static de.aservo.atlassian.bitbucket.confapi.rest.SettingsResource.SETTINGS_PATH;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AtlassianPluginsTestRunner.class)
+public class ResourceAccessFuncTest {
+
+    @ComponentImport
+    private final SecurityService securityService;
+
+    @ComponentImport
+    private final UserAdminService userAdminService;
+
+    @Inject
+    public ResourceAccessFuncTest(
+            final SecurityService securityService,
+            final UserAdminService userAdminService) {
+
+        this.securityService = securityService;
+        this.userAdminService = userAdminService;
+    }
+
+    @Test
+    public void testAccessForbiddenAsAnonymousUser() {
+        final String baseUrl = System.getProperty("baseurl");
+        final String resourceUrl = baseUrl + "/rest/confapi/1/" + SETTINGS_PATH;
+
+        final RestClient client = new RestClient();
+        final Resource resource = client.resource(resourceUrl);
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), resource.get().getStatusCode());
+    }
+
+    @Test
+    public void testAccessForbiddenAsNormalUser() {
+        ApplicationUser user = userAdminService.getUserDetails("test");
+
+        if (user == null) {
+            user = securityService
+                    .withPermission(Permission.ADMIN, "create new users")
+                    .call((UncheckedOperation<ApplicationUser>) () -> {
+                        userAdminService.createUser("test", "test", "test", "test@localhost");
+                        return userAdminService.getUserDetails("test");
+                    });
+            assert user != null;
+        }
+
+        final String baseUrl = System.getProperty("baseurl");
+        final String resourceUrl = baseUrl + "/rest/confapi/1/" + SETTINGS_PATH;
+
+        final BasicAuthSecurityHandler basicAuthHandler = new BasicAuthSecurityHandler();
+        basicAuthHandler.setUserName(user.getName());
+        basicAuthHandler.setPassword(user.getName());
+
+        final ClientConfig config = new ClientConfig();
+        config.handlers(basicAuthHandler);
+
+        final RestClient client = new RestClient(config);
+        final Resource resource = client.resource(resourceUrl);
+
+        assertEquals(Status.FORBIDDEN.getStatusCode(), resource.get().getStatusCode());
+
+        final ApplicationUser finalUser = user;
+        securityService
+                .withPermission(Permission.ADMIN, "create new users")
+                .call((UncheckedOperation<DetailedUser>) () -> {
+                    return userAdminService.deleteUser(finalUser.getName());
+                });
+    }
+
+    @Test
+    public void testAccessSuccessfulAsSysAdmin() {
+        final String baseUrl = System.getProperty("baseurl");
+        final String resourceUrl = baseUrl + "/rest/confapi/1/" + SETTINGS_PATH;
+
+        final BasicAuthSecurityHandler basicAuthHandler = new BasicAuthSecurityHandler();
+        basicAuthHandler.setUserName("admin");
+        basicAuthHandler.setPassword("admin");
+
+        final ClientConfig config = new ClientConfig();
+        config.handlers(basicAuthHandler);
+
+        final RestClient client = new RestClient(config);
+        final Resource resource = client.resource(resourceUrl);
+
+        assertEquals(Status.OK.getStatusCode(), resource.get().getStatusCode());
+    }
+
+}


### PR DESCRIPTION
Normal users should not be able to access any system configuration. The settings
REST endpoint has been accessible by normal users. Although they probably would
not have been able to set the system configuration, they should also not be able
to read it.

The plugin now makes sure that the current user has sysadmin permissions. The
permission checks are furthermore covered with unit and integration tests.

Unfortunately, integration tests are not executed by the pipeline yet as somehow Bitbucket integration tests cannot be executed without the Atlassian SDK (unlike Jira, Confluence and Crowd).